### PR TITLE
fix(changesets): update ignore list for renamed apps

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -7,5 +7,5 @@
   "access": "restricted",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
-  "ignore": ["web"]
+  "ignore": ["color-synthesizer", "color-code-pro"]
 }


### PR DESCRIPTION
The `ignore` option still referenced `web`, which was renamed to `color-synthesizer` (and `color-code-pro` was later added). Changesets throws a ValidationError on ignore entries that match no package, which has failed every Release run since the rename. Ignore both private apps so only @royalfig/color-palette-pro is versioned/published.


Claude-Session: https://claude.ai/code/session_01TDkG17p7Rwz89Diuu1mkJf